### PR TITLE
Bug fix

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -17,7 +17,7 @@ lazy val root = (project in file(".")).
     }).
   settings(scalaxbSettings: _*).
   settings(
-    sourceGenerators in Compile += (scalaxb in Compile).value,
+    sourceGenerators in Compile <+= (scalaxb in Compile),
     dispatchVersion in (Compile, scalaxb) := "$dispatch_version$",
     async in (Compile, scalaxb)           := true,
     packageName in (Compile, scalaxb)     := "$generated_package_name$"


### PR DESCRIPTION
This fix removes this exception
build.sbt:16: error: No implicit for Append.Value[Seq[sbt.Task[Seq[java.io.File]]], Seq[sbt.File]] found,
  so Seq[sbt.File] cannot be appended to Seq[sbt.Task[Seq[java.io.File]]]
    sourceGenerators in Compile += (scalaxb in Compile).value,
